### PR TITLE
Support Node.js 6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 'use strict'
 
 module.exports = function clone (obj, orig, shim = {}) {
-  const descriptors = Object.getOwnPropertyDescriptors(orig)
+  const proto = Object.getOwnPropertyDescriptor(orig, '__proto__')
+  const descriptors = proto ? { ['__proto__']: proto } : {}
+
+  for (const name of Object.getOwnPropertyNames(orig)) {
+    descriptors[name] = Object.getOwnPropertyDescriptor(orig, name)
+  }
 
   for (const name of Object.keys(shim)) {
     descriptors[name] = shim[name](descriptors[name])


### PR DESCRIPTION
`Object.getOwnPropertyDescriptors(...)` was not added until Node.js 7.x. This is functionally equivalent while still working in Node.js 6.x.